### PR TITLE
Revert to lz4net 1.0.5.93

### DIFF
--- a/src/Abc.Zebus.Directory.Cassandra.Tests/Abc.Zebus.Directory.Cassandra.Tests.csproj
+++ b/src/Abc.Zebus.Directory.Cassandra.Tests/Abc.Zebus.Directory.Cassandra.Tests.csproj
@@ -52,7 +52,7 @@
     </Reference>
     <Reference Include="LZ4">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\lz4net.1.0.9.93\lib\net40-client\LZ4.dll</HintPath>
+      <HintPath>..\packages\lz4net.1.0.5.93\lib\net40-client\LZ4.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Abc.Zebus.Directory.Cassandra.Tests/packages.config
+++ b/src/Abc.Zebus.Directory.Cassandra.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="CassandraCSharpDriver" version="2.7.2" targetFramework="net45" />
   <package id="CompareNETObjects" version="3.03.0.0" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="lz4net" version="1.0.9.93" targetFramework="net45" />
+  <package id="lz4net" version="1.0.5.93" targetFramework="net45" />
   <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />

--- a/src/Abc.Zebus.Directory.Cassandra/Abc.Zebus.Directory.Cassandra.csproj
+++ b/src/Abc.Zebus.Directory.Cassandra/Abc.Zebus.Directory.Cassandra.csproj
@@ -44,7 +44,7 @@
     </Reference>
     <Reference Include="LZ4">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\lz4net.1.0.9.93\lib\net40-client\LZ4.dll</HintPath>
+      <HintPath>..\packages\lz4net.1.0.5.93\lib\net40-client\LZ4.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Abc.Zebus.Directory.Cassandra/packages.config
+++ b/src/Abc.Zebus.Directory.Cassandra/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="CassandraCSharpDriver" version="2.7.2" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="lz4net" version="1.0.9.93" targetFramework="net45" />
+  <package id="lz4net" version="1.0.5.93" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="structuremap" version="3.1.6.186" targetFramework="net45" />


### PR DESCRIPTION
They changed the public key token on 1.0.9.93 (?!) which breaks CassandraCSharpDriver